### PR TITLE
Run using node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,5 +34,5 @@ output:
   settingsJsonString:
     description: Fully replaced settings file in json string format (use JSON.parse( needs.job.outputs.settingsJsonString ) to/use)
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
Thanks for this super handy action ⭐ !

I've bumped the action to use node20 as per https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

I've tested the forked version within my own repositories and it seems to behave as expected 🤷.